### PR TITLE
Standalone Sensor Mode - Make creport.json file list complete

### DIFF
--- a/pkg/app/sensor/app.go
+++ b/pkg/app/sensor/app.go
@@ -29,6 +29,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	defaultArtifactDirName = "/opt/dockerslim/artifacts"
+)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 func getCurrentPaths(root string) (map[string]interface{}, error) {
@@ -296,7 +300,14 @@ func runControlled(sensorCtx context.Context, dirName, mountPoint string) {
 
 				log.Info("sensor: waiting for monitor to finish...")
 
-				processReports(startCmd, mountPoint, monRes.peReport(), monRes.fanReport(), monRes.ptReport())
+				processReports(
+					defaultArtifactDirName,
+					startCmd,
+					mountPoint,
+					monRes.peReport(),
+					monRes.fanReport(),
+					monRes.ptReport(),
+				)
 
 				log.Info("sensor: monitor stopped...")
 				ipcServer.TryPublishEvt(&event.Message{Name: event.StopMonitorDone}, 3)
@@ -360,7 +371,14 @@ func runStandalone(
 
 	log.Info("sensor: target app is done.")
 
-	processReports(&startCmd, mountPoint, monRes.peReport(), monRes.fanReport(), ptReport)
+	processReports(
+		defaultArtifactDirName,
+		&startCmd,
+		mountPoint,
+		monRes.peReport(),
+		monRes.fanReport(),
+		ptReport,
+	)
 }
 
 func initSignalForwardingChannel(

--- a/pkg/app/sensor/data_processor.go
+++ b/pkg/app/sensor/data_processor.go
@@ -18,6 +18,7 @@ import (
 )
 
 func processReports(
+	artifactDirName string,
 	cmd *command.StartMonitor,
 	mountPoint string,
 	peReport *report.PeMonitorReport,
@@ -41,7 +42,7 @@ func processReports(
 
 	log.Debugf("processReports(): len(fanReport.ProcessFiles)=%v / fileCount=%v", len(fanReport.ProcessFiles), fileCount)
 	allFilesMap := findSymlinks(fileList, mountPoint)
-	saveResults(cmd, allFilesMap, fanReport, ptReport, peReport)
+	saveResults(artifactDirName, cmd, allFilesMap, fanReport, ptReport, peReport)
 }
 
 func getProcessChildren(pid int, targetPidList map[int]bool, processChildrenMap map[int][]int) {

--- a/pkg/report/container_report.go
+++ b/pkg/report/container_report.go
@@ -11,10 +11,10 @@ type ArtifactType int
 
 // Artifact type ID constants
 const (
-	DirArtifactType     = 1
-	FileArtifactType    = 2
-	SymlinkArtifactType = 3
-	UnknownArtifactType = 99
+	DirArtifactType     ArtifactType = 1
+	FileArtifactType    ArtifactType = 2
+	SymlinkArtifactType ArtifactType = 3
+	UnknownArtifactType ArtifactType = 99
 )
 
 // DefaultContainerReportFileName is the default container report file name


### PR DESCRIPTION
While a proper solution is still required, at the moment it's done by re-enumerating the artifacts/files folder right before generating the creport file.

[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============


Why
===============


How Tested
===============


